### PR TITLE
upgraded npm packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,9 +72,8 @@ module.exports = function(options) {
       },
       onend: function() {
         // as soon as everything has been parsed, add the found files to the stream
-        // add the script to the output stream
         // look for scripts in all available search paths. Available search paths are:
-        // - The file.base folder (i.e. the folder in which the index.html lies)
+        // - The file.base folder (i.e. the folder in which the index.html resides)
         // - any other specified folders (options.searchPaths)
         var searchPaths = array.union([file.base], options.searchPaths.map(function(sp) {
           return path.join(process.cwd(), sp);
@@ -88,6 +87,7 @@ module.exports = function(options) {
         vfs.src(scriptsGlob, {
           cwd: file.base,
           base: '.',
+          allowEmpty: true,
           // we want to keep the order as specified in the index.html
           nosort: true,
           // do not match directories, just files, since we want to pipe those

--- a/package.json
+++ b/package.json
@@ -22,16 +22,17 @@
     "htmlparser2"
   ],
   "devDependencies": {
-    "gulp": "^3.6.0",
-    "gulp-coveralls": "^0.1.0",
-    "gulp-eslint": "^0.8.0",
-    "gulp-istanbul": "^0.8.1",
-    "gulp-jscs": "^1.1.0",
-    "gulp-jshint": "^1.5.3",
-    "gulp-mocha": "^2.0.0",
-    "gulp-plumber": "^1.0.0",
-    "jshint-stylish": "^1.0.0",
-    "should": "^7.0.1"
+    "gulp": "^3.9.1",
+    "gulp-coveralls": "^0.1.4",
+    "gulp-eslint": "^3.0.1",
+    "gulp-istanbul": "^1.1.1",
+    "gulp-jscs": "^4.0.0",
+    "gulp-jshint": "^2.0.1",
+    "gulp-mocha": "^3.0.1",
+    "gulp-plumber": "^1.1.0",
+    "jshint": "^2.9.3",
+    "jshint-stylish": "^2.2.1",
+    "should": "^11.1.1"
   },
   "scripts": {
     "test": "gulp"
@@ -39,10 +40,10 @@
   "license": "MIT",
   "dependencies": {
     "array-extended": "0.0.11",
-    "gulp-util": "^3.0.5",
-    "htmlparser2": "^3.8.3",
+    "gulp-util": "^3.0.7",
+    "htmlparser2": "^3.9.2",
     "merge": "^1.2.0",
-    "through2": "^2.0.0",
-    "vinyl-fs": "^1.0.0"
+    "through2": "^2.0.1",
+    "vinyl-fs": "^2.4.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "gulp-scripts-index",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Input html file(s) and get a stream of all referenced scripts which can then be usedfor further processing like concatenation, minification or for testing",
   "homepage": "",
   "repository": "burnedikt/gulp-scripts-index",
   "author": {
     "name": "Benedikt Reiser",
     "email": "benedikt.reiser@gmail.com",
-    "url": "benedikt-reiser.de"
+    "url": "burnedikt.com"
   },
   "files": [
     "lib"


### PR DESCRIPTION
- see package.json for changes
- had to add `allowEmpty` option to glob since non-matchin singular file globs emit errors in the most recent version of [glob-stream](https://github.com/gulpjs/glob-stream#globstreamglobs-options)
